### PR TITLE
Make the demo work on Firefox

### DIFF
--- a/app.html
+++ b/app.html
@@ -26,7 +26,7 @@
         <video id="video-demo" controls="controls" poster="videos/jsdetection.jpg" width="640" height="480"
                onclick="if(/Android/.test(navigator.userAgent))this.play();">
             <source src="videos/jsdetection.mp4" type="video/mp4"/>
-            <source src="videos/jsdetection.ogg" type="video/ogg"/>
+            <source src="videos/jsdetection.ogv" type="video/ogv"/>
             <source src="videos/jsdetection.webm" type="video/webm"/>
             Your browser doesn't support the HTML5 video tag.
         </video>

--- a/js/app.js
+++ b/js/app.js
@@ -73,6 +73,11 @@
 			video.src = stream;
 			initialize();
 		}, webcamError);
+	} else if (navigator.mozGetUserMedia) {
+		navigator.mozGetUserMedia({audio: true, video: true}, function (stream) {
+			video.mozSrcObject = stream;
+			initialize();
+		}, webcamError);
 	} else if (navigator.webkitGetUserMedia) {
 		navigator.webkitGetUserMedia({audio: true, video: true}, function (stream) {
 			video.src = window.webkitURL.createObjectURL(stream);
@@ -99,7 +104,11 @@
 		$('.introduction').fadeOut();
 		$('.allow').fadeOut();
 		$('.loading').delay(300).fadeIn();
-		start();
+		video.addEventListener('canplay', function canplayed() {
+			video.removeEventListener('canplay', canplayed);
+			// Video is only available until a short time.
+			start();
+		});
 	}
 
 	function start() {
@@ -133,7 +142,11 @@
 	}
 
 	function drawVideo() {
-		contextSource.drawImage(video, 0, 0, video.width, video.height);
+		try {
+			contextSource.drawImage(video, 0, 0, video.width, video.height);
+		} catch (e) {
+			console.error(e);
+		}
 	}
 
 	function blend() {


### PR DESCRIPTION
According to 
https://developer.mozilla.org/en-US/docs/Web/Guide/API/WebRTC/Taking_webcam_photos

Sadly we still need special handling for `mozGetUserMedia()`, for now.
